### PR TITLE
Expose anchored elements list

### DIFF
--- a/anchor.js
+++ b/anchor.js
@@ -50,7 +50,8 @@ function AnchorJS(options) {
         newTidyText,
         readableID,
         anchor,
-        visibleOptionToUse;
+        visibleOptionToUse,
+        indexesToDrop = [];
 
     // We reapply options here because somebody may have overwritten the default options object when setting options.
     // For example, this overwrites all options but visible:
@@ -83,6 +84,10 @@ function AnchorJS(options) {
     });
 
     for (i = 0; i < elements.length; i++) {
+      if (this.hasAnchorJSLink(elements[i])) {
+        indexesToDrop.push(i);
+        continue;
+      }
 
       if (elements[i].hasAttribute('id')) {
         elementID = elements[i].getAttribute('id');
@@ -153,6 +158,9 @@ function AnchorJS(options) {
       }
     }
 
+    for (i = 0; i < indexesToDrop.length; i++) {
+      elements.splice(indexesToDrop[i] - i, 1);
+    }
     return this;
   };
 

--- a/anchor.js
+++ b/anchor.js
@@ -7,6 +7,7 @@
 function AnchorJS(options) {
   'use strict';
   this.options = options || {};
+  this.elements = [];
 
   /**
    * Assigns options to the internal options object, and provides defaults.
@@ -161,6 +162,8 @@ function AnchorJS(options) {
     for (i = 0; i < indexesToDrop.length; i++) {
       elements.splice(indexesToDrop[i] - i, 1);
     }
+    this.elements = this.elements.concat(elements);
+
     return this;
   };
 
@@ -178,6 +181,12 @@ function AnchorJS(options) {
     for (var i = 0; i < elements.length; i++) {
       domAnchor = elements[i].querySelector('.anchorjs-link');
       if (domAnchor) {
+        // Drop the element from our main list, if it's in there.
+        index = this.elements.indexOf(elements[i]);
+        if (index !== -1) {
+          this.elements.splice(index, 1);
+        }
+        // Remove the anchor from the DOM.
         elements[i].removeChild(domAnchor);
       }
     }

--- a/anchor.js
+++ b/anchor.js
@@ -194,6 +194,13 @@ function AnchorJS(options) {
   };
 
   /**
+   * Removes all anchorjs links. Mostly used for tests.
+   */
+  this.removeAll = function() {
+    this.remove(this.elements);
+  };
+
+  /**
    * Urlify - Refine text so it makes a good ID.
    *
    * To do this, we remove apostrophes, replace nonsafe characters with hyphens,

--- a/anchor.js
+++ b/anchor.js
@@ -104,17 +104,13 @@ function AnchorJS(options) {
             newTidyText = tidyText + '-' + count;
           }
 
-          // .indexOf is only supported in IE9+.
           index = idList.indexOf(newTidyText);
           count += 1;
         } while (index !== -1);
         index = undefined;
         idList.push(newTidyText);
 
-        // Assign it to our element.
-        // Currently the setAttribute element is only supported in IE9 and above.
         elements[i].setAttribute('id', newTidyText);
-
         elementID = newTidyText;
       }
 
@@ -207,7 +203,6 @@ function AnchorJS(options) {
    * remove extra hyphens, truncate, trim hyphens, and make lowercase.
    *
    * @param  {String} text - Any text. Usually pulled from the webpage element we are linking to.
-   * @param  {?Object} options - Optional option overrides.
    * @return {String}      - hyphen-delimited text for use in IDs and URLs.
    */
   this.urlify = function(text) {

--- a/anchor.js
+++ b/anchor.js
@@ -34,8 +34,9 @@ function AnchorJS(options) {
 
   /**
    * Add anchor links to page elements.
-   * @param  {String} selector  A CSS selector for targeting the elements you wish to add anchor links to.
-   * @return {this}             The AnchorJS object
+   * @param  {String|Array|Nodelist} selector - A CSS selector for targeting the elements you wish to add anchor links
+   *                                            to. Also accepts an array or nodeList containing the relavant elements.
+   * @return {this}                           - The AnchorJS object
    */
   this.add = function(selector) {
     var elements,
@@ -65,11 +66,10 @@ function AnchorJS(options) {
     // Provide a sensible default selector, if none is given.
     if (!selector) {
       selector = 'h1, h2, h3, h4, h5, h6';
-    } else if (typeof selector !== 'string') {
-      throw new Error('The selector provided to AnchorJS was invalid.');
     }
 
-    elements = document.querySelectorAll(selector);
+    elements = _getElements(selector);
+
     if (elements.length === 0) {
       return false;
     }
@@ -158,12 +158,15 @@ function AnchorJS(options) {
 
   /**
    * Removes all anchorjs-links from elements targed by the selector.
-   * @param  {String} selector  A CSS selector used to target elements containing anchor links.
-   * @return {this}             The AnchorJS object
+   * @param  {String|Array|Nodelist} selector - A CSS selector string targeting elements with anchor links,
+   *                                       	  	OR a nodeList / array containing the DOM elements.
+   * @return {this}                           - The AnchorJS object
    */
   this.remove = function(selector) {
-    var domAnchor,
-        elements = document.querySelectorAll(selector);
+    var index,
+        domAnchor,
+        elements = _getElements(selector);
+
     for (var i = 0; i < elements.length; i++) {
       domAnchor = elements[i].querySelector('.anchorjs-link');
       if (domAnchor) {
@@ -206,6 +209,40 @@ function AnchorJS(options) {
 
     return urlText;
   };
+
+  /**
+   * Determines if this element already has an AnchorJS link on it.
+   * Uses this technique: http://stackoverflow.com/a/5898748/1154642
+   * @param    {HTMLElemnt}  el - a DOM node
+   * @return   {Boolean}     true/false
+   */
+  this.hasAnchorJSLink = function(el) {
+    var hasLeftAnchor = (' ' + el.firstChild.className + ' ').indexOf(' anchorjs-link ') > -1,
+        hasRightAnchor = (' ' + el.lastChild.className + ' ').indexOf(' anchorjs-link ') > -1;
+
+    return hasLeftAnchor || hasRightAnchor;
+  };
+
+  /**
+   * Turns a selector, nodeList, or array of elements into an array of elements (so we can use array methods).
+   * It also throws errors on any other inputs. Used to handle inputs to .add and .remove.
+   * @param  {String|Array|Nodelist} input - A CSS selector string targeting elements with anchor links,
+   *                                       	 OR a nodeList / array containing the DOM elements.
+   * @return {Array} - An array containing the elements we want.
+   */
+  function _getElements(input) {
+    var elements;
+    if (typeof input === 'string' || input instanceof String) {
+      // See https://davidwalsh.name/nodelist-array for the technique transforming nodeList -> Array.
+      elements = [].slice.call(document.querySelectorAll(input));
+    // I checked the 'input instanceof NodeList' test in IE9 and modern browsers and it worked for me.
+    } else if (Array.isArray(input) || input instanceof NodeList) {
+      elements = [].slice.call(input);
+    } else {
+      throw new Error('The selector provided to AnchorJS was invalid.');
+    }
+    return elements;
+  }
 
   /**
    * _addBaselineStyles

--- a/test/spec/AnchorSpec.js
+++ b/test/spec/AnchorSpec.js
@@ -193,6 +193,18 @@ describe('AnchorJS', function() {
     }).toThrowError('The selector provided to AnchorJS was invalid.');
   });
 
+  it('silently prevents an anchor from being added twice to the same element', function() {
+    var anchorLinkList1,
+        anchorLinkList2;
+    anchors.add('h1');
+
+    anchorLinkList1 = document.querySelectorAll('h1 > .anchorjs-link');
+    expect(anchorLinkList1.length).toEqual(1);
+    anchors.add('h1');
+    anchorLinkList2 = document.querySelectorAll('h1 > .anchorjs-link');
+    expect(anchorLinkList2.length).toEqual(1);
+  });
+
   describe('urlify', function() {
     it('preserves unicode characters', function() {
       var text1Before = 'Заголовок, содержащий 29 не-ASCII символов',

--- a/test/spec/AnchorSpec.js
+++ b/test/spec/AnchorSpec.js
@@ -169,9 +169,9 @@ describe('AnchorJS', function() {
   });
 
   it('should increment new IDs if multiple IDs are found on a page.', function() {
-    var el1 = appendElementToBody('h2', 'Example Title'),
-        el2 = appendElementToBody('h2', 'Example Title'),
+    var el2 = appendElementToBody('h2', 'Example Title'),
         el3 = appendElementToBody('h2', 'Example Title'),
+        el4 = appendElementToBody('h2', 'Example Title'),
         id1,
         id2,
         id3,
@@ -198,9 +198,9 @@ describe('AnchorJS', function() {
     expect(id3).toEqual('example-title-2');
     expect(href3).toEqual('#example-title-2');
 
-    document.body.removeChild(el1);
     document.body.removeChild(el2);
     document.body.removeChild(el3);
+    document.body.removeChild(el4);
   });
 
   it('should throw an error if an inappropriate selector is provided.', function() {

--- a/test/spec/AnchorSpec.js
+++ b/test/spec/AnchorSpec.js
@@ -205,6 +205,47 @@ describe('AnchorJS', function() {
     expect(anchorLinkList2.length).toEqual(1);
   });
 
+  describe('exposed elements list', function() {
+    var el2,
+        el3,
+        el4;
+
+    beforeEach(function() {
+      el2 = appendElementToBody('h2', 'Example Title 1');
+      el3 = appendElementToBody('h2', 'Example Title 2');
+      el4 = appendElementToBody('h3', 'Example Title 3');
+    });
+
+    afterEach(function() {
+      document.body.removeChild(el2);
+      document.body.removeChild(el3);
+      document.body.removeChild(el4);
+    });
+
+    it('contains added anchors', function() {
+      anchors.add('h2');
+      expect(anchors.elements.length).toEqual(2);
+      expect(anchors.elements[0].textContent).toEqual('Example Title 1');
+      expect(anchors.elements[1].textContent).toEqual('Example Title 2');
+    });
+
+    it('contains combined anchors from multiple adds', function() {
+      anchors.add('h2');
+      expect(anchors.elements.length).toEqual(2);
+      anchors.add('h3');
+      expect(anchors.elements.length).toEqual(3);
+    });
+
+    it('doesn\'t contain removed anchors', function() {
+      anchors.add('h2, h3');
+      expect(anchors.elements.length).toEqual(3);
+      expect(anchors.elements.indexOf(el4)).toEqual(2);
+      anchors.remove('h3');
+      expect(anchors.elements.length).toEqual(2);
+      expect(anchors.elements.indexOf(el4)).toEqual(-1);
+    });
+  });
+
   describe('urlify', function() {
     it('preserves unicode characters', function() {
       var text1Before = 'Заголовок, содержащий 29 не-ASCII символов',

--- a/test/spec/AnchorSpec.js
+++ b/test/spec/AnchorSpec.js
@@ -14,11 +14,44 @@ describe('AnchorJS', function() {
     document.body.removeChild(el1);
   });
 
+  it('can detect if an element has an AnchorJS link', function() {
+    var anchorLink,
+        el2 = appendElementToBody('h2', 'Example Title');
+
+    anchors.add('h2');
+    anchorLink = document.querySelector('h2 > .anchorjs-link');
+    expect(anchorLink).not.toBe(null); // reference test
+    expect(anchors.hasAnchorJSLink(el2)).toBe(true);
+
+    document.body.removeChild(el2);
+  });
+
   it('should add an anchor link to an h1 by default', function() {
     var anchorLink;
     anchors.add();
     anchorLink = document.querySelector('h1 > .anchorjs-link');
     expect(anchorLink).not.toBe(null);
+  });
+
+  it('add/remove accepts a string (selector), nodelist, or array of els', function() {
+    var el2 = appendElementToBody('h2', 'Example Title');
+
+    anchors.add('h2');
+    expect(anchors.hasAnchorJSLink(el2)).toBe(true);
+    anchors.remove('h2');
+    expect(anchors.hasAnchorJSLink(el2)).toBe(false);
+
+    anchors.add(document.querySelectorAll('h2'));
+    expect(anchors.hasAnchorJSLink(el2)).toBe(true);
+    anchors.remove(document.querySelectorAll('h2'));
+    expect(anchors.hasAnchorJSLink(el2)).toBe(false);
+
+    anchors.add([document.querySelector('h2')]);
+    expect(anchors.hasAnchorJSLink(el2)).toBe(true);
+    anchors.remove([document.querySelector('h2')]);
+    expect(anchors.hasAnchorJSLink(el2)).toBe(false);
+
+    document.body.removeChild(el2);
   });
 
   it('should set the expected default options', function() {

--- a/test/spec/AnchorSpec.js
+++ b/test/spec/AnchorSpec.js
@@ -11,6 +11,7 @@ describe('AnchorJS', function() {
   });
 
   afterEach(function() {
+    anchors.removeAll();
     document.body.removeChild(el1);
   });
 
@@ -117,6 +118,21 @@ describe('AnchorJS', function() {
     anchors.remove('h1');
     anchorLinkAfter = document.querySelector('h1 > .anchorjs-link');
     expect(anchorLinkAfter).toBe(null);
+  });
+
+  it('can remove all anchors with removeAll', function() {
+    var el2 = appendElementToBody('h2', 'Example Title');
+
+    anchors.add('h1, h2');
+    expect(anchors.hasAnchorJSLink(el1)).toBe(true);
+    expect(anchors.hasAnchorJSLink(el2)).toBe(true);
+
+    anchors.removeAll();
+    expect(anchors.hasAnchorJSLink(el1)).toBe(false);
+    expect(anchors.hasAnchorJSLink(el2)).toBe(false);
+    expect(anchors.elements.length).toBe(0);
+
+    document.body.removeChild(el2);
   });
 
   it('can chain methods.', function() {


### PR DESCRIPTION
This includes [the exposed elements feature](https://github.com/bryanbraun/anchorjs/issues/50) and a couple small improvements for supporting the exposed elements list like:

- Preventing multiple anchors from being added to the same element (and thus, duplicate elements from being in the elements list)
- Allow `anchors.add` and `anchors.remove` to take an array of elements or a nodeList instead of the selector-string.
- Add `anchors.removeAll`.

*The main commit for the exposed elements feature is: 200cfd2*

**Examples usage:**
```js
// Given a page with an h1 and h2 on it...
console.log(anchors.elements) // => []
anchors.add('h1');
console.log(anchors.elements); // => [HTMLElement]
anchors.add('h2');
console.log(anchors.elements); // => [HTMLElement, HTMLElement]
anchors.remove('h1, h2')
console.log(anchors.elements) // => []
```