### PR TITLE
adds a callback option so a developer can modify the anchor or element

### DIFF
--- a/anchor.js
+++ b/anchor.js
@@ -41,6 +41,7 @@
       opts.class = opts.hasOwnProperty('class') ? opts.class : ''; // Accepts any class name.
       // Using Math.floor here will ensure the value is Number-cast and an integer.
       opts.truncate = opts.hasOwnProperty('truncate') ? Math.floor(opts.truncate) : 64; // Accepts any value that can be typecast to a number.
+      opts.anchorCreated = opts.hasOwnProperty('anchorCreated') ? opts.anchorCreated : null; // no callback by default
     }
 
     _applyRemainingDefaultOptions(this.options);
@@ -173,6 +174,11 @@
         } else { // if the option provided is `right` (or anything else).
           anchor.style.paddingLeft = '0.375em';
           elements[i].appendChild(anchor);
+        }
+
+        //execute the callback
+        if (this.options.anchorCreated !== null) {
+            this.options.anchorCreated(elements[i]);
         }
       }
 


### PR DESCRIPTION
I've added the ability to specify a callback in the options. This is useful if a developer needs to modify the anchor once it's made. In my case I needed to offset the anchor that was created due to a fixed header that existed on a page.  I was able to do something like this with a callback:

```
anchors.options = {
            placement: 'left',
            visible: "hover",
            anchorCreated: function(e) {
                var id = $(e).attr('id');
                //clear it's id since we'll be creating a custom anchor point with an offset
                $(e).removeAttr("id");
                $(e).addClass("anchorjs-heading");
                $(e).prepend("<a class='offset-anchor' id='" + id + "'></a>");
            }
        };
```

which creates a different element as the anchor with my own styles which i offset from the top like: 

```
a.offset-anchor {
    visibility: hidden;
    position: relative;
    top: -100px;
    display: block;
}
```