### PR TITLE
include loading instructions for Node/CommonJS

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,9 @@ anchors.add('p');</code></pre>
     <p>Then include the anchor.js file (or anchor.min.js) in your webpage.</p>
     <pre>&lt;script src="anchor.js"&gt;&lt;/script&gt;</pre>
     <p>You could also include it via a CDN like <a href="https://cdnjs.com/libraries/anchor-js">CDNJS</a> or <a href="http://www.jsdelivr.com/projects/anchorjs">jsDelivr</a>.</p>
+    <p>If you're using it from Node/CommonJS, include it via:</p>
+    <pre><code>var anchorJS = require('anchor-js');
+var anchors = new anchorJS();</code></pre>
 
     <h2>Basic Usage</h2>
     <p>AnchorJS provides the <code>anchors.add()</code> method which takes a CSS selector (similar to jQuery) for targeting elements you want to deep-link. Here are some usage examples.</p>


### PR DESCRIPTION
Fixes https://github.com/bryanbraun/anchorjs/issues/69. For the latter half of that issue, there might be more docs to add around page loading order and when `anchors.add()` should be called, but that seems like a separate issue.

/cc @k-funk 