### PR TITLE
Fix header in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then include the anchor.js file (or anchor.min.js) in your webpage.
 
 You could also include it via a CDN like [CDNJS](https://cdnjs.com/libraries/anchor-js) or [jsDelivr](http://www.jsdelivr.com/projects/anchorjs).
 
-##Usage
+## Usage
 See **[the Documentation](http://bryanbraun.github.io/anchorjs#basic-usage)** for detailed instructions.
 
 ## Compatibility


### PR DESCRIPTION
This PR fixes a broken header in the README:

> ![](https://cloud.githubusercontent.com/assets/230581/24222630/11cb8a22-0f29-11e7-8295-7d8575d7a15c.png)