### PR TITLE
:bug: fix(a11y): make aria-label text less redundant for anchors

### DIFF
--- a/anchor.js
+++ b/anchor.js
@@ -32,6 +32,7 @@
       opts.icon = opts.hasOwnProperty('icon') ? opts.icon : '\ue9cb'; // Accepts characters (and also URLs?), like  '#', '¶', '❡', or '§'.
       opts.visible = opts.hasOwnProperty('visible') ? opts.visible : 'hover'; // Also accepts 'always' & 'touch'
       opts.placement = opts.hasOwnProperty('placement') ? opts.placement : 'right'; // Also accepts 'left'
+      opts.ariaLabel = opts.hasOwnProperty('ariaLabel') ? opts.ariaLabel : 'Anchor'; // Accepts any text.
       opts.class = opts.hasOwnProperty('class') ? opts.class : ''; // Accepts any class name.
       // Using Math.floor here will ensure the value is Number-cast and an integer.
       opts.truncate = opts.hasOwnProperty('truncate') ? Math.floor(opts.truncate) : 64; // Accepts any value that can be typecast to a number.
@@ -138,7 +139,7 @@
         anchor = document.createElement('a');
         anchor.className = 'anchorjs-link ' + this.options.class;
         anchor.href = '#' + elementID;
-        anchor.setAttribute('aria-label', 'Anchor');
+        anchor.setAttribute('aria-label', this.options.ariaLabel);
         anchor.setAttribute('data-anchorjs-icon', this.options.icon);
 
         if (visibleOptionToUse === 'always') {

--- a/anchor.js
+++ b/anchor.js
@@ -134,11 +134,11 @@
         readableID = elementID.replace(/-/g, ' ');
 
         // The following code builds the following DOM structure in a more effiecient (albeit opaque) way.
-        // '<a class="anchorjs-link ' + this.options.class + '" href="#' + elementID + '" aria-label="Anchor link for: ' + readableID + '" data-anchorjs-icon="' + this.options.icon + '"></a>';
+        // '<a class="anchorjs-link ' + this.options.class + '" href="#' + elementID + '" aria-label="Anchor" data-anchorjs-icon="' + this.options.icon + '"></a>';
         anchor = document.createElement('a');
         anchor.className = 'anchorjs-link ' + this.options.class;
         anchor.href = '#' + elementID;
-        anchor.setAttribute('aria-label', 'Anchor link for: ' + readableID);
+        anchor.setAttribute('aria-label', 'Anchor');
         anchor.setAttribute('data-anchorjs-icon', this.options.icon);
 
         if (visibleOptionToUse === 'always') {

--- a/docs/index.html
+++ b/docs/index.html
@@ -164,6 +164,12 @@ document.addEventListener("DOMContentLoaded", function(event) {
           <td><code>64</code></td>
           <td>Truncates the generated ID to the specified character length. <small>Note: the length may not be exactly the same, if there are dangling spaces or hyphens to be trimmed.</small></td>
         </tr>
+        <tr>
+          <td><code>ariaLabel</code></td>
+          <td>(any text)</td>
+          <td><code>Anchor</code></td>
+          <td>Allows you to customize or translate the default aria-label ("Anchor"), for screenreaders that encounter the link.</td>
+        </tr>
       </tbody>
     </table>
     <p>For example:</p>

--- a/test/spec/AnchorSpec.js
+++ b/test/spec/AnchorSpec.js
@@ -92,6 +92,7 @@ describe('AnchorJS', function() {
     expect(anchors.options.icon).toEqual('\ue9cb');
     expect(anchors.options.visible).toEqual('hover');
     expect(anchors.options.placement).toEqual('right');
+    expect(anchors.options.ariaLabel).toEqual('Anchor');
     expect(anchors.options.class).toEqual('');
     expect(anchors.options.truncate).toEqual(64);
   });
@@ -109,6 +110,8 @@ describe('AnchorJS', function() {
     expect(anchorObj.options.visible).toEqual('hover');
     expect(anchors.options.placement).toEqual('right');
     expect(anchorObj.options.placement).toEqual('right');
+    expect(anchors.options.ariaLabel).toEqual('Anchor');
+    expect(anchorObj.options.ariaLabel).toEqual('Anchor');
   });
 
   it('should set baseline styles in the document head', function() {
@@ -423,6 +426,18 @@ describe('AnchorJS', function() {
       anchorNode = document.getElementsByTagName('h1')[0].lastChild;
       expect(anchorNode.style.position).toEqual('');
       expect(anchorNode.style.marginLeft).toEqual('');
+    });
+  });
+
+  describe('ARIA label option', function() {
+    it('should allow users to add custom or translated aria-labels', function() {
+      var ariaLabelText;
+
+      // an example (probably inaccurate) Russian translation of "anchor"
+      anchors.options.ariaLabel = 'якорь';
+      anchors.add('h1');
+      ariaLabelText = document.querySelector('.anchorjs-link').getAttribute('aria-label');
+      expect(ariaLabelText).toEqual('якорь');
     });
   });
 


### PR DESCRIPTION
Fixes #63