### PR TITLE
add options.base to prepend the anchor

### DIFF
--- a/anchor.js
+++ b/anchor.js
@@ -34,6 +34,7 @@
       opts.placement = opts.hasOwnProperty('placement') ? opts.placement : 'right'; // Also accepts 'left'
       opts.ariaLabel = opts.hasOwnProperty('ariaLabel') ? opts.ariaLabel : 'Anchor'; // Accepts any text.
       opts.class = opts.hasOwnProperty('class') ? opts.class : ''; // Accepts any class name.
+      opts.base = opts.hasOwnProperty('base') ? opts.base : ''; // Accepts any base URI.
       // Using Math.floor here will ensure the value is Number-cast and an integer.
       opts.truncate = opts.hasOwnProperty('truncate') ? Math.floor(opts.truncate) : 64; // Accepts any value that can be typecast to a number.
     }
@@ -135,14 +136,15 @@
 
         readableID = elementID.replace(/-/g, ' ');
 
-        // The following code builds the following DOM structure in a more efficient (albeit opaque) way.
-        // '<a class="anchorjs-link ' + this.options.class + '" href="#' + elementID + '" aria-label="Anchor" data-anchorjs-icon="' + this.options.icon + '"></a>';
+        // The following code builds the following DOM structure in a more effiecient (albeit opaque) way.
+        // '<a class="anchorjs-link ' + this.options.class + '" href="this.options.base + #' + elementID + '" aria-label="Anchor" data-anchorjs-icon="' + this.options.icon + '"></a>';
         anchor = document.createElement('a');
         anchor.className = 'anchorjs-link ' + this.options.class;
         anchor.setAttribute('aria-label', this.options.ariaLabel);
         anchor.setAttribute('data-anchorjs-icon', this.options.icon);
         // Adjust the href if there's a <base> tag. See https://github.com/bryanbraun/anchorjs/issues/98
         hrefBase = document.querySelector('base') ? window.location.pathname + window.location.search : '';
+        hrefBase = this.options.base || hrefBase;
         anchor.href = hrefBase + '#' + elementID;
 
         if (visibleOptionToUse === 'always') {

--- a/docs/anchor.js
+++ b/docs/anchor.js
@@ -34,6 +34,7 @@
       opts.placement = opts.hasOwnProperty('placement') ? opts.placement : 'right'; // Also accepts 'left'
       opts.ariaLabel = opts.hasOwnProperty('ariaLabel') ? opts.ariaLabel : 'Anchor'; // Accepts any text.
       opts.class = opts.hasOwnProperty('class') ? opts.class : ''; // Accepts any class name.
+      opts.base = opts.hasOwnProperty('base') ? opts.base : ''; // Accepts any base URI.
       // Using Math.floor here will ensure the value is Number-cast and an integer.
       opts.truncate = opts.hasOwnProperty('truncate') ? Math.floor(opts.truncate) : 64; // Accepts any value that can be typecast to a number.
     }
@@ -68,6 +69,7 @@
           readableID,
           anchor,
           visibleOptionToUse,
+          hrefBase,
           indexesToDrop = [];
 
       // We reapply options here because somebody may have overwritten the default options object when setting options.
@@ -135,12 +137,15 @@
         readableID = elementID.replace(/-/g, ' ');
 
         // The following code builds the following DOM structure in a more effiecient (albeit opaque) way.
-        // '<a class="anchorjs-link ' + this.options.class + '" href="#' + elementID + '" aria-label="Anchor" data-anchorjs-icon="' + this.options.icon + '"></a>';
+        // '<a class="anchorjs-link ' + this.options.class + '" href="this.options.base + #' + elementID + '" aria-label="Anchor" data-anchorjs-icon="' + this.options.icon + '"></a>';
         anchor = document.createElement('a');
         anchor.className = 'anchorjs-link ' + this.options.class;
-        anchor.href = '#' + elementID;
         anchor.setAttribute('aria-label', this.options.ariaLabel);
         anchor.setAttribute('data-anchorjs-icon', this.options.icon);
+        // Adjust the href if there's a <base> tag. See https://github.com/bryanbraun/anchorjs/issues/98
+        hrefBase = document.querySelector('base') ? window.location.pathname + window.location.search : '';
+        hrefBase = this.options.base || hrefBase;
+        anchor.href = hrefBase + '#' + elementID;
 
         if (visibleOptionToUse === 'always') {
           anchor.style.opacity = '1';

--- a/docs/index.html
+++ b/docs/index.html
@@ -164,6 +164,12 @@ document.addEventListener("DOMContentLoaded", function(event) {
             <td>Adds the provided class(es) to the anchor html.</td>
           </tr>
           <tr>
+            <td><code>base</code></td>
+            <td>(any string)</td>
+            <td>(none)</td>
+            <td>Prepends the base URI to the anchor <code>href</code>.</td>
+          </tr>
+          <tr>
             <td><code>truncate</code></td>
             <td>(any positive number)</td>
             <td><code>64</code></td>

--- a/test/spec/AnchorSpec.js
+++ b/test/spec/AnchorSpec.js
@@ -100,6 +100,7 @@ describe('AnchorJS', function() {
     expect(anchors.options.placement).toEqual('right');
     expect(anchors.options.ariaLabel).toEqual('Anchor');
     expect(anchors.options.class).toEqual('');
+    expect(anchors.options.base).toEqual('');
     expect(anchors.options.truncate).toEqual(64);
   });
 
@@ -259,6 +260,14 @@ describe('AnchorJS', function() {
     document.body.removeChild(el2);
     document.body.removeChild(el3);
     document.body.removeChild(el4);
+  });
+
+  it('should create a URL-appropriate href with a custom base', function() {
+    var href;
+    anchors.options = { base: 'ohana-means-family' };
+    anchors.add('h1');
+    href = document.querySelector('.anchorjs-link').getAttribute('href');
+    expect(href).toEqual('ohana-means-family#⚡⚡-dont-forget-url-fragments-should-be-i18n-friendly-hyphenated');
   });
 
   it('should throw an error if an inappropriate selector is provided.', function() {


### PR DESCRIPTION
The target use-case (for me) is to support permalinks with AnchorJS. Right now, I have pages that will:

- show the anchor from the main page (e.g., `https://lilo.localhost#ohana`)
- show the anchor from the blog post (e.g., `https://lilo.localhost/stitch-rocks#ohana`)

I'd like the first line item to (also) be `https://lilo.localhost/stitch-rocks#ohana`.