### PR TITLE
Expose `urlify`

### DIFF
--- a/anchor.js
+++ b/anchor.js
@@ -19,10 +19,44 @@
   }
 }(this, function () {
   'use strict';
+  
+   /**
+     * Urlify - Refine text so it makes a good ID.
+     *
+     * To do this, we remove apostrophes, replace non-safe characters with hyphens,
+     * remove extra hyphens, truncate, trim hyphens, and make lowercase.
+     *
+     * @param  {String} text - Any text. Usually pulled from the webpage element we are linking to.
+     * @return {String}      - hyphen-delimited text for use in IDs and URLs.
+     */
+    function urlify(text) {
+      // Regex for finding the non-safe URL characters (many need escaping): & +$,:;=?@"#{}|^~[`%!'<>]./()*\ (newlines, tabs, backspace, & vertical tabs)
+      var nonsafeChars = /[& +$,:;=?@"#{}|^~[`%!'<>\]\.\/\(\)\*\\\n\t\b\v]/g,
+          urlText;
+
+      // The reason we include this _applyRemainingDefaultOptions is so urlify can be called independently,
+      // even after setting options. This can be useful for tests or other applications.
+      if (!this.options.truncate) {
+        _applyRemainingDefaultOptions(this.options);
+      }
+
+      // Note: we trim hyphens after truncating because truncating can cause dangling hyphens.
+      // Example string:                      // " ⚡⚡ Don't forget: URL fragments should be i18n-friendly, hyphenated, short, and clean."
+      urlText = text.trim()                   // "⚡⚡ Don't forget: URL fragments should be i18n-friendly, hyphenated, short, and clean."
+        .replace(/\'/gi, '')                  // "⚡⚡ Dont forget: URL fragments should be i18n-friendly, hyphenated, short, and clean."
+        .replace(nonsafeChars, '-')           // "⚡⚡-Dont-forget--URL-fragments-should-be-i18n-friendly--hyphenated--short--and-clean-"
+        .replace(/-{2,}/g, '-')               // "⚡⚡-Dont-forget-URL-fragments-should-be-i18n-friendly-hyphenated-short-and-clean-"
+        .substring(0, this.options.truncate)  // "⚡⚡-Dont-forget-URL-fragments-should-be-i18n-friendly-hyphenated-"
+        .replace(/^-+|-+$/gm, '')             // "⚡⚡-Dont-forget-URL-fragments-should-be-i18n-friendly-hyphenated"
+        .toLowerCase();                       // "⚡⚡-dont-forget-url-fragments-should-be-i18n-friendly-hyphenated"
+
+      return urlText;
+    };
 
   function AnchorJS(options) {
     this.options = options || {};
     this.elements = [];
+    this.urlify = urlify;
 
     /**
      * Assigns options to the internal options object, and provides defaults.
@@ -225,39 +259,6 @@
     };
 
     /**
-     * Urlify - Refine text so it makes a good ID.
-     *
-     * To do this, we remove apostrophes, replace non-safe characters with hyphens,
-     * remove extra hyphens, truncate, trim hyphens, and make lowercase.
-     *
-     * @param  {String} text - Any text. Usually pulled from the webpage element we are linking to.
-     * @return {String}      - hyphen-delimited text for use in IDs and URLs.
-     */
-    this.urlify = function(text) {
-      // Regex for finding the non-safe URL characters (many need escaping): & +$,:;=?@"#{}|^~[`%!'<>]./()*\ (newlines, tabs, backspace, & vertical tabs)
-      var nonsafeChars = /[& +$,:;=?@"#{}|^~[`%!'<>\]\.\/\(\)\*\\\n\t\b\v]/g,
-          urlText;
-
-      // The reason we include this _applyRemainingDefaultOptions is so urlify can be called independently,
-      // even after setting options. This can be useful for tests or other applications.
-      if (!this.options.truncate) {
-        _applyRemainingDefaultOptions(this.options);
-      }
-
-      // Note: we trim hyphens after truncating because truncating can cause dangling hyphens.
-      // Example string:                      // " ⚡⚡ Don't forget: URL fragments should be i18n-friendly, hyphenated, short, and clean."
-      urlText = text.trim()                   // "⚡⚡ Don't forget: URL fragments should be i18n-friendly, hyphenated, short, and clean."
-        .replace(/\'/gi, '')                  // "⚡⚡ Dont forget: URL fragments should be i18n-friendly, hyphenated, short, and clean."
-        .replace(nonsafeChars, '-')           // "⚡⚡-Dont-forget--URL-fragments-should-be-i18n-friendly--hyphenated--short--and-clean-"
-        .replace(/-{2,}/g, '-')               // "⚡⚡-Dont-forget-URL-fragments-should-be-i18n-friendly-hyphenated-short-and-clean-"
-        .substring(0, this.options.truncate)  // "⚡⚡-Dont-forget-URL-fragments-should-be-i18n-friendly-hyphenated-"
-        .replace(/^-+|-+$/gm, '')             // "⚡⚡-Dont-forget-URL-fragments-should-be-i18n-friendly-hyphenated"
-        .toLowerCase();                       // "⚡⚡-dont-forget-url-fragments-should-be-i18n-friendly-hyphenated"
-
-      return urlText;
-    };
-
-    /**
      * Determines if this element already has an AnchorJS link on it.
      * Uses this technique: http://stackoverflow.com/a/5898748/1154642
      * @param    {HTMLElement}  el - a DOM node
@@ -344,6 +345,8 @@
       style.sheet.insertRule(anchorjsLinkFontFace, style.sheet.cssRules.length);
     }
   }
+
+  AnchorJS.urlify = urlify
 
   return AnchorJS;
 }));


### PR DESCRIPTION
Hello,

I extracted the `urlify` method out of the constructor scope since it can be used without using `Anchors` directly.

That's is useful when you are working with server-side application and you want to associate a slug with your HTML elements titles.

The point is that you are interested in generating the same slug to later use AnchorJS in the frontend and be possible link the things properly.