### PR TITLE
Update anchor.js

### DIFF
--- a/anchor.js
+++ b/anchor.js
@@ -67,7 +67,6 @@
           count,
           tidyText,
           newTidyText,
-          readableID,
           anchor,
           visibleOptionToUse,
           hrefBase,
@@ -134,8 +133,6 @@
           elements[i].setAttribute('id', newTidyText);
           elementID = newTidyText;
         }
-
-        readableID = elementID.replace(/-/g, ' ');
 
         // The following code efficiently builds this DOM structure:
         // `<a class="anchorjs-link ${this.options.class}"


### PR DESCRIPTION
Remove unused variable `readableID`

I haven't check the code closely, but I suppose this was a leftover, or otherwise it should be `elementID = elementID.replace(/-/g, ' ')`, so let me know @bryanbraun 

BTW found with https://lgtm.com/projects/g/bryanbraun/anchorjs/?mode=list which is now owned by GitHub and you could integrate :)