### PR TITLE
Replace PhantomJS with Headless Chrome #114

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1473,6 +1473,15 @@
         "useragent": "2.3.0"
       }
     },
+    "karma-chrome-launcher": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz",
+      "integrity": "sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==",
+      "dev": true,
+      "requires": {
+        "which": "^1.2.1"
+      }
+    },
     "karma-cli": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/karma-cli/-/karma-cli-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
   "devDependencies": {
     "eslint": "6.5.1",
     "jasmine-core": "3.5.0",
-    "karma": "4.3.0",
+    "karma": "^4.3.0",
+    "karma-chrome-launcher": "^3.1.0",
     "karma-cli": "2.0.0",
     "karma-jasmine": "2.0.1",
-    "karma-phantomjs-launcher": "1.0.4",
-    "phantomjs-prebuilt": "2.1.16",
     "uglify-js": "3.6.1"
   }
 }

--- a/test/config.js
+++ b/test/config.js
@@ -49,7 +49,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['ChromeHeadless'],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits


### PR DESCRIPTION
- Removed Phanto js Karma launcher and added Chrome headless launcher in package.json
- Updated Karma conf file to use chrome headless