### PR TITLE
Switch to GitHub Actions CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+on: [push, pull_request]
+env:
+  CI: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+
+      - run: node --version
+      - run: npm --version
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-    - "node"
-branches:
-  only:
-    - master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AnchorJS [![Build Status](https://img.shields.io/travis/bryanbraun/anchorjs/master.svg?style=flat)](https://travis-ci.org/bryanbraun/anchorjs)
+# AnchorJS [![Build Status](https://github.com/bryanbraun/anchorjs/workflows/Tests/badge.svg)](https://github.com/bryanbraun/anchorjs/actions?workflow=Tests)
 
 A JavaScript utility for adding deep anchor links ([like these](https://ux.stackexchange.com/q/36304/33248)) to existing page content. AnchorJS is lightweight, accessible, and has no dependencies.
 


### PR DESCRIPTION
@bryanbraun:

1. register for GitHub Actions https://github.com/features/actions
2. we can't use the alias `node` yet, so I went with the latest 12 LTS
3. before you merge this make sure you remove any Travis CI hooks/apps/integrations

Preview: <https://github.com/XhmikosR/anchorjs/runs/281158300>

This will fire after the above and after you merge this for security reasons.