### PR TITLE
uglify: remove `screw-ie8` option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "anchor-js",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint .",
     "lockfile-lint": "lockfile-lint --allowed-hosts npm --validate-https --type npm --path package-lock.json",
     "release": "npm-run-all uglify add-banner copy-dist",
-    "uglify": "uglifyjs anchor.js --compress --mangle --screw-ie8 --comments \"/Copyright/\" -o anchor.min.js",
+    "uglify": "uglifyjs anchor.js --compress --mangle --comments \"/Copyright/\" -o anchor.min.js",
     "test": "npm-run-all --parallel lint lockfile-lint --serial jasmine"
   },
   "dependencies": {},


### PR DESCRIPTION
It seems it has been dropped