### PR TITLE
Update styles.css

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -182,7 +182,7 @@ pre > code {
 }
 
 .options-table-wrap {
-  overflow: scroll;
+  overflow: auto;
 }
 .options-table {
   min-width: 500px;


### PR DESCRIPTION
Switch `overflow: scroll` to `auto` so that the bars show only when needed, i.e. not on desktop