### PR TITLE
[#151] Remove jquery from doc

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -829,7 +829,6 @@ anchors.add('h3');</code></pre>
     </div>
     <footer class="footer"><p><small>Made by <a href="https://www.bryanbraun.com/">Bryan</a>. You should <a href="https://twitter.com/intent/tweet?text=Hi%20%40BryanEBraun%2C%20">say hi</a> sometime. 👋</small></p></footer>
   </section>
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
   <script src="anchor.js"></script>
   <script src="scripts.js"></script>
   <script>

--- a/docs/scripts.js
+++ b/docs/scripts.js
@@ -1,12 +1,31 @@
-$(document).ready(function() {
-  var preEls = $('pre');
+function slideExampleCode(e) {
+  e.preventDefault();
 
-  $('.example-code-link').click(function(e) {
-    e.preventDefault();
-    $(this).parent().next().slideToggle();
-  });
+  let slide = e.target.parentElement.nextElementSibling;
+  slide.classList.toggle('open');
+
+  if(slide.classList.contains('open')) {
+    slide.style.maxHeight = slide.scrollHeight + 'px'; // open the example code
+  } else {
+    slide.style.maxHeight = 0; // close the example code
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  let toggleButtons = document.getElementsByClassName('example-code-link'); // get the buttons
+  
+  for(i = 0; i < toggleButtons.length; i++) {
+    toggleButtons[i].addEventListener("click", slideExampleCode); // add the event to each button
+  }
 
   // Dynamically add PrismJS class for syntax highlight
-  preEls.filter('[class*="js"]').find('code').addClass('language-javascript');
-  preEls.filter('.css').find('code').addClass('language-css');
+  let jsCodes = document.querySelectorAll('pre[class*="js"] code');
+  for(i = 0; i < jsCodes.length; i++) {
+    jsCodes[i].classList.add('language-javascript');
+  }
+
+  let cssCodes = document.querySelectorAll('pre.css code');
+  for(i = 0; i < cssCodes.length; i++) {
+    cssCodes[i].classList.add('language-css');
+  }
 });

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -262,7 +262,9 @@ pre > code {
 }
 
 .example-code {
-  display: none;
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height .25s ease-out;
 }
 
 .css {


### PR DESCRIPTION
Use vanilla js instead of jQuery for multiple things in the doc like on ready, toggleSlide and to "manually" add classes.
Issue : #151 